### PR TITLE
Fixed memory allocation in stopwatch class. Also faster execution.

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -45,7 +45,7 @@ class Program
     static async Task<int> GetSBOMS(string organization, string githubtoken, string folder)
     {
         var startTime = Stopwatch.GetTimestamp();
-        
+
         using var client = new HttpClient();
         client.BaseAddress = BaseAdress;
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", githubtoken);

--- a/Program.cs
+++ b/Program.cs
@@ -44,8 +44,8 @@ class Program
 
     static async Task<int> GetSBOMS(string organization, string githubtoken, string folder)
     {
-        var watch = Stopwatch.StartNew();
-
+        var startTime = Stopwatch.GetTimestamp();
+        
         using var client = new HttpClient();
         client.BaseAddress = BaseAdress;
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", githubtoken);
@@ -57,7 +57,7 @@ class Program
 
         await SaveSBOMS(client, organization, reponames, folder);
 
-        Console.WriteLine($"Saved {Directory.GetFiles("sboms").Length} sboms in {watch.Elapsed}");
+        Console.WriteLine($"Saved {Directory.GetFiles("sboms").Length} sboms in {Stopwatch.GetElapsedTime(startTime)}");
 
         return 0;
     }


### PR DESCRIPTION
GetTimestamp does not allocate any memory on the heap unlike StartNew.